### PR TITLE
Spiral galaxy map generator round 2

### DIFF
--- a/src/MapGenerationBadger.cs
+++ b/src/MapGenerationBadger.cs
@@ -1885,7 +1885,7 @@ to GameData/Configuration/MapType/KDL_MapTypes.xml
 
       bool singleLargeCentralCluster = Context.QualityRandom.NextBool();
 
-      int radius = 75;
+      int radius = 70;
       int distForThisArm = 95;
       int minDistanceBetweenPlanets = 25;
 
@@ -1913,10 +1913,10 @@ to GameData/Configuration/MapType/KDL_MapTypes.xml
       {
         int percent = Context.QualityRandom.NextWithInclusiveUpperBound(1, 100);
         List<int> clusterSizesListToAddTo;
-        if (percent > 85)
+        if (percent > 90)
         {
           clusterSizesListToAddTo = outerArmClusterSizes;
-        } else if (percent > 40)
+        } else if (percent > 45)
         {
           clusterSizesListToAddTo = innerArmClusterSizes;
         } else
@@ -2029,22 +2029,10 @@ to GameData/Configuration/MapType/KDL_MapTypes.xml
         var innerArm1 = new List<Planet>();
         var innerArm1Center = CreateClusterOfPlanets(innerArm1, galaxy, Context, radius, galacticCenter, minDistanceBetweenPlanets+10, alignmentNumber, innerArmClusterSizes[2 * i], ref allPoints, firstArmAngle, linkingMethod, distForThisArm * 2+20);
 
-
-        ArcenDebugging.ArcenDebugLogSingleLine(string.Format("creating outer arm clusters {0}", i), Verbosity.ShowAsInfo);
-
-        linkingMethod = BadgerUtilityMethods.getRandomLinkMethod(percentSpanningTree, percentGabriel,
-                                                                  percentRNG, percentSpanningTreeWithConnections,
-                                                                  Context);
-        var outerArm1 = new List<Planet>();
-        var outerArm1Center = CreateClusterOfPlanets(outerArm1, galaxy, Context, radius+30, galacticCenter, minDistanceBetweenPlanets+30, alignmentNumber, outerArmClusterSizes[2 * i], ref allPoints, firstArmAngle.Add(fakeRotation), LinkMethod.SpanningTreeWithConnections, distForThisArm * 4);
-        ArcenDebugging.ArcenDebugLogSingleLine(string.Format("linking outer arm clusters {0}", i), Verbosity.ShowAsInfo);
-
-        BadgerUtilityMethods.linkPlanetLists(innerArm1, outerArm1, outerArm1Center, false);
-        BadgerUtilityMethods.linkPlanetLists(bodyCluster, innerArm1, innerArm1Center, false);
-
-
-        ArcenDebugging.ArcenDebugLogSingleLine(string.Format("creating second inner arm clusters {0}", i), Verbosity.DoNotShow);
-
+        
+        ArcenDebugging.ArcenDebugLogSingleLine(string.Format("creating second inner arm clusters {0}", i), Verbosity.DoNotShow);       
+        var innerArm2 = new List<Planet>();
+        var innerArm2Center = CreateClusterOfPlanets(innerArm2, galaxy, Context, radius, galacticCenter, minDistanceBetweenPlanets+10, alignmentNumber, innerArmClusterSizes[2 * i + 1], ref allPoints, secondArmAngle, linkingMethod, distForThisArm * 2+35);
 
         percentGabriel = 15;
         percentRNG = 15;
@@ -2053,10 +2041,15 @@ to GameData/Configuration/MapType/KDL_MapTypes.xml
         linkingMethod = BadgerUtilityMethods.getRandomLinkMethod(percentSpanningTree, percentGabriel,
                                                                   percentRNG, percentSpanningTreeWithConnections,
                                                                   Context);
-        var innerArm2 = new List<Planet>();
-        var innerArm2Center = CreateClusterOfPlanets(innerArm2, galaxy, Context, radius, galacticCenter, minDistanceBetweenPlanets+10, alignmentNumber, innerArmClusterSizes[2 * i + 1], ref allPoints, secondArmAngle, linkingMethod, distForThisArm * 2+35);
-        ArcenDebugging.ArcenDebugLogSingleLine(string.Format("linking second inner arm clusters {0}", i), Verbosity.DoNotShow);
 
+        ArcenDebugging.ArcenDebugLogSingleLine(string.Format("creating outer arm clusters {0}", i), Verbosity.ShowAsInfo);
+
+        linkingMethod = BadgerUtilityMethods.getRandomLinkMethod(percentSpanningTree, percentGabriel,
+                                                                  percentRNG, percentSpanningTreeWithConnections,
+                                                                  Context);
+        var outerArm1 = new List<Planet>();
+        var outerArm1Center = CreateClusterOfPlanets(outerArm1, galaxy, Context, radius + 30, galacticCenter, minDistanceBetweenPlanets + 30, alignmentNumber, outerArmClusterSizes[2 * i], ref allPoints, firstArmAngle.Add(fakeRotation), LinkMethod.SpanningTreeWithConnections, distForThisArm * 4);
+        ArcenDebugging.ArcenDebugLogSingleLine(string.Format("linking outer arm clusters {0}", i), Verbosity.ShowAsInfo);
 
         ArcenDebugging.ArcenDebugLogSingleLine(string.Format("creating second outer arm clusters {0}", i), Verbosity.DoNotShow);
 
@@ -2065,10 +2058,12 @@ to GameData/Configuration/MapType/KDL_MapTypes.xml
                                                                   Context);
         var outerArm2 = new List<Planet>();
         var outerArm2Center = CreateClusterOfPlanets(outerArm2, galaxy, Context, radius+30, galacticCenter, minDistanceBetweenPlanets+30, alignmentNumber, outerArmClusterSizes[2 * i + 1], ref allPoints, secondArmAngle.Add(fakeRotation), linkingMethod, distForThisArm * 4);
+
+        // Link clusters together - inner to outer, body to inner
+        BadgerUtilityMethods.linkPlanetLists(innerArm1, outerArm1, outerArm1Center, false);
+        BadgerUtilityMethods.linkPlanetLists(bodyCluster, innerArm1, innerArm1Center, false);
         BadgerUtilityMethods.linkPlanetLists(innerArm2, outerArm2, outerArm2Center, false);
         BadgerUtilityMethods.linkPlanetLists(bodyCluster, innerArm2, innerArm2Center, false);
-
-
       }
 
       if (!singleLargeCentralCluster)

--- a/src/MapGenerationBadger.cs
+++ b/src/MapGenerationBadger.cs
@@ -1856,7 +1856,7 @@ to GameData/Configuration/MapType/KDL_MapTypes.xml
     public override void Generate(Galaxy galaxy, ArcenSimContext Context, int numberToSeed, MapTypeData mapType)
     { 
       int symmetryFactor = 2;
-      numberToSeed = Context.QualityRandom.NextWithInclusiveUpperBound(10 / 5, 120 / 5) * 5; // randomize for testing
+      numberToSeed = 120; // Context.QualityRandom.NextWithInclusiveUpperBound(10 / 5, 120 / 5) * 5; // randomize for testing
 
 
       if (numberToSeed < 20)
@@ -1872,7 +1872,7 @@ to GameData/Configuration/MapType/KDL_MapTypes.xml
         // Context.QualityRandom.NextBool()
         symmetryFactor = Context.QualityRandom.NextWithInclusiveUpperBound(2,3);
       }
-      else if(numberToSeed < 120)
+      else if(numberToSeed < 110)
       {
         symmetryFactor = Context.QualityRandom.NextWithInclusiveUpperBound(2, 4);
       }
@@ -1881,7 +1881,7 @@ to GameData/Configuration/MapType/KDL_MapTypes.xml
         symmetryFactor = Context.QualityRandom.NextWithInclusiveUpperBound(3, 5);
       }
 
-      int minPlanetsPerCluster = Math.Max(numberToSeed / (symmetryFactor * 5) - 1, 2);
+      int minPlanetsPerCluster = Math.Max(numberToSeed / (symmetryFactor * 5), 2);
 
       bool singleLargeCentralCluster = Context.QualityRandom.NextBool();
 
@@ -1913,10 +1913,10 @@ to GameData/Configuration/MapType/KDL_MapTypes.xml
       {
         int percent = Context.QualityRandom.NextWithInclusiveUpperBound(1, 100);
         List<int> clusterSizesListToAddTo;
-        if (percent > 90)
+        if (percent > 70)
         {
           clusterSizesListToAddTo = outerArmClusterSizes;
-        } else if (percent > 45)
+        } else if (percent > 30)
         {
           clusterSizesListToAddTo = innerArmClusterSizes;
         } else


### PR DESCRIPTION
The Octopus map type has a bunch of tuning:

* Sometimes there's one large central cluster instead of a ring of them
* The number of arms is randomized, depending on the size of the map; at 80 planets there are 4, 6, or 8 arms.
* The outer parts of the arms have planets spread a bit farther apart, and are more likely to be sparsely connected
* Bunch of parameter tuning
* Decreased logging since it stopped crashing